### PR TITLE
Add .shopifyignore file

### DIFF
--- a/extensions/theme-extension/.shopifyignore
+++ b/extensions/theme-extension/.shopifyignore
@@ -1,0 +1,4 @@
+frontend/*
+node_modules/*
+package.json
+vite.config.ts


### PR DESCRIPTION
Was using this as reference for creating a theme app extension, but had to spend a bit of time digging for the solution to allow additional folders to exist in the extension folder and keep the CLI happy. Thought this may help others in the future.